### PR TITLE
Feature/backend-get-delete-favourites

### DIFF
--- a/db/queries/widgets.js
+++ b/db/queries/widgets.js
@@ -80,6 +80,20 @@ const addPoint = (point) => {
 // favourites
 
 /**
+ * Get favourite maps from database given user_id.
+ * @param {string}} user_id.
+ * @return {Promise<{}>} A promise to the point.
+ */
+const getFavouritesWithUserId = (id) => {
+  return query(`SELECT f.*, u1.name AS user_name, m.name AS map_name, m.owner_id, u2.name AS owenr_name, m.description, m.category, m.map_pins, m.is_private
+  FROM favourites AS f
+  JOIN users AS u1 ON f.user_id = u1.id
+  JOIN maps AS m ON f.map_id = m.id
+  JOIN users AS u2 ON m.owner_id = u2.id
+  WHERE user_id = $1;`, [id], result => result.rows);
+};
+
+/**
  * Add a favourite to the database.
  * @param {{}}} user_id, map_id.
  * @return {Promise<{}>} A promise to the property.
@@ -99,5 +113,6 @@ module.exports = {
   getAllNoPrivateMaps,
   addMap,
   addPoint,
+  getFavouritesWithUserId,
   addFavourite,
 };

--- a/db/queries/widgets.js
+++ b/db/queries/widgets.js
@@ -107,6 +107,20 @@ const addFavourite = (favourite) => {
   return query(`INSERT INTO favourites (map_id, user_id) VALUES ($1, $2) RETURNING *;`, queryValues, result => result.rows);
 };
 
+/**
+ * Delete a favourite.
+ * @param {{}}} user_id, map_id.
+ * @return {Promise<{}>} A promise to the property.
+ */
+const deleteFavourite = (favourite) => {
+  const queryValues = [
+    favourite.map_id,
+    favourite.user_id,
+  ];
+
+  return query(`DELETE FROM favourites WHERE map_id = $1 AND user_id = $2 RETURNING *;`, queryValues, result => result.rows);
+};
+
 module.exports = {
   getMapsWithOwnerId,
   getPointsWithMapId,
@@ -115,4 +129,5 @@ module.exports = {
   addPoint,
   getFavouritesWithUserId,
   addFavourite,
+  deleteFavourite,
 };

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -77,8 +77,21 @@ router.post('/points', (req, res) => {
 });
 
 // favourites
+router.get('/favourites', (req, res) => {
+  const { userId } = req.session;
+  widgetsQueries.getFavouritesWithUserId(userId)
+    .then(favourites => {
+      res.send(favourites);
+    })
+    .catch(err => {
+      res
+        .status(500)
+        .json({ error: err.message });
+    });
+});
+
 router.post('/favourites', (req, res) => {
-  const userId = req.session.userId;
+  const { userId } = req.session;
   const { map_id } = req.body;
   widgetsQueries.addFavourite({ map_id, user_id: userId })
     .then(favourite => {

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -92,8 +92,22 @@ router.get('/favourites', (req, res) => {
 
 router.post('/favourites', (req, res) => {
   const { userId } = req.session;
-  const { map_id } = req.body;
-  widgetsQueries.addFavourite({ map_id, user_id: userId })
+  const { mapId } = req.body;
+  widgetsQueries.addFavourite({ map_id: mapId, user_id: userId })
+    .then(favourite => {
+      res.send(favourite);
+    })
+    .catch(err => {
+      res
+        .status(500)
+        .json({ error: err.message });
+    });
+});
+
+router.delete('/favourites', (req, res) => {
+  const { userId } = req.session;
+  const { mapId } = req.query;
+  widgetsQueries.deleteFavourite({ map_id: mapId, user_id: userId })
     .then(favourite => {
       res.send(favourite);
     })


### PR DESCRIPTION
# Description
Added contributor name to getPointWithMapId.

## Trello ticket 
https://trello.com/c/tzjQCME2
https://trello.com/c/VLodljCV

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- getFavouritesWithUserId
Checked the query work in a browser.
`localhost:8080/api/widgets/favourites`
[![Image from Gyazo](https://i.gyazo.com/7da1bd85ccd4caca0e8637f063393298.png)](https://gyazo.com/7da1bd85ccd4caca0e8637f063393298)

- deleteFavourite
Checked the query work using curl forcing userId 1.
```
$ curl 'localhost:8080/api/widgets/favourites?mapId=2' -XDELETE            [12:47:13]
[{"id":1,"map_id":2,"user_id":1}]%
```
