### PR TITLE
Feature/backend-get-point-mapId-contributorId

### DIFF
--- a/db/queries/widgets.js
+++ b/db/queries/widgets.js
@@ -46,13 +46,32 @@ const addMap = (map) => {
 
 /**
  * Get points from database given map_id.
- * @param {string}} map_id.
- * @return {Promise<{}>} A promise to the point.
+ * @param {{ mapId: string, contirbutorId: string }} map_id, contributor_id.
+ * @return {Promise<{}>} A promise to the points.
  */
-const getPointsWithMapId = (id) => {
-  return query(`SELECT p.*, u.name AS contributor_name FROM points AS p
+const getPointsWithMapIdAndContributorId = (point) => {
+  let whereClause = '';
+  let queryValues = [];
+  if (!!point.map_id && !!point.contirbutor_id) {
+    whereClause += 'WHERE map_id = $1 AND contributor_id = $2';
+    queryValues = [point.map_id, point.contirbutor_id];
+  }
+
+  if (!!point.map_id && !point.contirbutor_id) {
+    whereClause += 'WHERE map_id = $1';
+    queryValues = [point.map_id];
+  }
+
+  if (!point.map_id && !!point.contirbutor_id) {
+    whereClause += 'WHERE contributor_id = $1';
+    queryValues = [point.contirbutor_id];
+  }
+
+  return query(`SELECT m.name AS map_name, u.name AS contributor_name, p.* FROM points AS p
   JOIN users AS u ON p.contributor_id = u.id
-  WHERE map_id = $1;`, [id], result => result.rows);
+  JOIN maps AS m ON p.map_id = m.id
+  ${whereClause}
+  ORDER BY map_name ASC;`, queryValues, result => result.rows);
 };
 
 /**
@@ -159,8 +178,8 @@ const deleteFavourite = (favourite) => {
 
 module.exports = {
   getMapsWithOwnerId,
-  getPointsWithMapId,
   getAllNoPrivateMaps,
+  getPointsWithMapIdAndContributorId,
   addMap,
   addPoint,
   updatePoint,

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -51,8 +51,8 @@ router.post('/maps', (req, res) => {
 
 // points
 router.get('/points', (req, res) => {
-  const { mapId } = req.query;
-  widgetsQueries.getPointsWithMapId(mapId)
+  const { mapId, contributorId } = req.query;
+  widgetsQueries.getPointsWithMapIdAndContributorId({ map_id: mapId, contirbutor_id: contributorId })
     .then(points => {
       res.json({ points });
     })


### PR DESCRIPTION
# Description
Modified get points query to search map id and contributor id.

## Trello ticket 
https://trello.com/c/ZJo1GeFN

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Checked the query work in a browser address bar.

- `localhost:8080/api/widgets/points`
[![Image from Gyazo](https://i.gyazo.com/8f48b587512b1687a30f28da16cbd660.png)](https://gyazo.com/8f48b587512b1687a30f28da16cbd660)

- `localhost:8080/api/widgets/points?mapId=3`
[![Image from Gyazo](https://i.gyazo.com/4847f58d92a6537320d9ae769a79a4a1.png)](https://gyazo.com/4847f58d92a6537320d9ae769a79a4a1)

- `localhost:8080/api/widgets/points?mapId=3&contributorId=2`
[![Image from Gyazo](https://i.gyazo.com/c26b5e9e894144eb77ae0705c3ac913c.png)](https://gyazo.com/c26b5e9e894144eb77ae0705c3ac913c)

- `localhost:8080/api/widgets/points?contributorId=2`
[![Image from Gyazo](https://i.gyazo.com/4acd11c6855dd6511b8ad8cba02dd379.png)](https://gyazo.com/4acd11c6855dd6511b8ad8cba02dd379)