### PR TITLE
Fix/backend-add-favourite

### DIFF
--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -119,7 +119,7 @@ router.get('/favourites', (req, res) => {
 
 router.post('/favourites', (req, res) => {
   const { userId } = req.session;
-  const { mapId } = req.body;
+  const { mapId } = req.query;
   widgetsQueries.addFavourite({ map_id: mapId, user_id: userId })
     .then(favourite => {
       res.send(favourite);


### PR DESCRIPTION
# Description
Modify post favourite route to get mapId from req.query.

## Trello ticket 
https://trello.com/c/RQidNfjh

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Checked the query work using curl.
```
$ curl 'localhost:8080/api/widgets/favourites?mapId=3' -X POST
{"id":4,"map_id":3,"user_id":3}%
```