### PR TITLE
Feature/backend-map-pins-text

### DIFF
--- a/db/schema/01_schema.sql
+++ b/db/schema/01_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE maps (
   owner_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
   description TEXT,
   category VARCHAR(32) NOT NULL,
-  map_pins VARCHAR(255),
+  map_pins TEXT,
   is_private BOOLEAN NOT NULL DEFAULT false
 );
 


### PR DESCRIPTION
# Description
Changed the map_pins type to TEXT from VARCHAR.

## Trello ticket 
https://trello.com/c/5QW8sGaH

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran the schema and made sure that map_pins type is TEXT.
```
midterm=# \i db/schema/01_schema.sql
DROP TABLE
DROP TABLE
DROP TABLE
DROP TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
midterm=# \d maps
                                   Table "public.maps"
   Column    |          Type          |                     Modifiers
-------------+------------------------+---------------------------------------------------
 id          | integer                | not null default nextval('maps_id_seq'::regclass)
 name        | character varying(255) | not null
 owner_id    | integer                |
 description | text                   |
 category    | character varying(32)  | not null
 map_pins    | text                   |
 is_private  | boolean                | not null default false
Indexes:
    "maps_pkey" PRIMARY KEY, btree (id)
Foreign-key constraints:
    "maps_owner_id_fkey" FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
Referenced by:
    TABLE "favourites" CONSTRAINT "favourites_map_id_fkey" FOREIGN KEY (map_id) REFERENCES maps(id) ON DELETE CASCADE
    TABLE "points" CONSTRAINT "points_map_id_fkey" FOREIGN KEY (map_id) REFERENCES maps(id) ON DELETE CASCADE

midterm=#
```