### PR TITLE
Feature/backend-delete-map

### DIFF
--- a/db/connection.js
+++ b/db/connection.js
@@ -19,7 +19,10 @@ const query = (text, params, callback) => {
       console.log('executed query', { text, duration, params, rows: result.rowCount });
       return callback(result);
     })
-    .catch(err => console.log(err.message));
+    .catch(err => {
+      console.log(err.message);
+      return err.message;
+    });
 };
 
 module.exports = query;

--- a/db/queries/widgets.js
+++ b/db/queries/widgets.js
@@ -42,6 +42,15 @@ const addMap = (map) => {
   `, queryValues, result => result.rows[0]);
 };
 
+/**
+ * Delete a map.
+ * @param {string}} map id.
+ * @return {Promise<{}>} A promise to the point.
+ */
+const deleteMap = (id) => {
+  return query(`DELETE FROM maps WHERE id = $1 RETURNING *;`, [id], result => result.rows[0]);
+};
+
 // points
 
 /**
@@ -126,12 +135,13 @@ const updatePoint = (point) => {
 
 /**
  * Delete a point.
- * @param {{}}} point id.
+ * @param {string}} point id.
  * @return {Promise<{}>} A promise to the point.
  */
 const deletePoint = (id) => {
   return query(`DELETE FROM points WHERE id = $1 RETURNING *;`, [id], result => result.rows[0]);
 };
+
 // favourites
 
 /**
@@ -181,6 +191,7 @@ module.exports = {
   getAllNoPrivateMaps,
   getPointsWithMapIdAndContributorId,
   addMap,
+  deleteMap,
   addPoint,
   updatePoint,
   deletePoint,

--- a/db/queries/widgets.js
+++ b/db/queries/widgets.js
@@ -8,7 +8,7 @@ const query = require('../connection');
  * @return {Promise<{}>} A promise to the map.
  */
 const getMapsWithOwnerId = (id) => {
-  return query('SELECT * FROM maps WHERE owner_id = $1;', [id], result => result.rows);
+  return query('SELECT * FROM maps WHERE owner_id = $1 ORDER BY name ASC;', [id], result => result.rows);
 };
 
 /**
@@ -80,7 +80,7 @@ const getPointsWithMapIdAndContributorId = (point) => {
   JOIN users AS u ON p.contributor_id = u.id
   JOIN maps AS m ON p.map_id = m.id
   ${whereClause}
-  ORDER BY map_name ASC;`, queryValues, result => result.rows);
+  ORDER BY map_name ASC, p.title ASC;`, queryValues, result => result.rows);
 };
 
 /**

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -48,6 +48,32 @@ router.post('/maps', (req, res) => {
     });
 });
 
+router.delete('/maps', (req, res) => {
+  const { userId } = req.session;
+  const { mapId } = req.query;
+  let canDelete = false;
+
+  widgetsQueries.getMapsWithOwnerId(userId)
+    .then(maps => {
+      canDelete = maps.map(m => m.id).includes(Number(mapId));
+      console.log(canDelete);
+      if (!canDelete) {
+        res.status(400)
+          .json({ error: 'Invalid values'});
+        return;
+      }
+      widgetsQueries.deleteMap(mapId)
+        .then(map => {
+          res.send(map);
+        })
+        .catch(err => {
+          res
+            .status(500)
+            .json({ error: err.message });
+        });
+    });
+});
+
 // points
 router.get('/points', (req, res) => {
   const { mapId, contributorId } = req.query;

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -51,18 +51,19 @@ router.post('/maps', (req, res) => {
 router.delete('/maps', (req, res) => {
   const { userId } = req.session;
   const { mapId } = req.query;
-  let canDelete = false;
 
   widgetsQueries.getMapsWithOwnerId(userId)
     .then(maps => {
-      canDelete = maps.map(m => m.id).includes(Number(mapId));
-      console.log(canDelete);
-      if (!canDelete) {
+      return maps.map(m => m.id).includes(Number(mapId));
+    })
+    .then(value => {
+      if (!value) {
         res.status(400)
           .json({ error: 'Invalid values'});
         return;
       }
-      widgetsQueries.deleteMap(mapId)
+
+      return widgetsQueries.deleteMap(mapId)
         .then(map => {
           res.send(map);
         })
@@ -71,6 +72,14 @@ router.delete('/maps', (req, res) => {
             .status(500)
             .json({ error: err.message });
         });
+    })
+    .then(map => {
+      res.send(map);
+    })
+    .catch(err => {
+      res
+        .status(500)
+        .json({ error: err.message });
     });
 });
 

--- a/routes/widgets-api.js
+++ b/routes/widgets-api.js
@@ -54,9 +54,11 @@ router.delete('/maps', (req, res) => {
 
   widgetsQueries.getMapsWithOwnerId(userId)
     .then(maps => {
+      // return boolean whether the user own the given mapId
       return maps.map(m => m.id).includes(Number(mapId));
     })
     .then(value => {
+      // if the returned value is false, the user don't own the map and response an error
       if (!value) {
         res.status(400)
           .json({ error: 'Invalid values'});


### PR DESCRIPTION
# Description
- Created a delete map query and route.
- Added ORDER BY ASC on point names in GET /api/widgets/points
- Added ORDER BY ASC on point names in GET /api/widgets/maps

## Trello ticket 
- https://trello.com/c/O8ZwBGKc
- https://trello.com/c/MgN5MVhu
- https://trello.com/c/oz2Ud0Kn

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Checked the queries work using curl

- Delete a  map
Checked the query using curl command forcing the userId=1.
```
[atsuyuki:~]
$ curl 'localhost:8080/api/widgets/maps?mapId=2' -X DELETE                            [15:20:47]
{"id":2,"name":"Best fishing spots","owner_id":1,"description":"Fishing for fun Club","category":"Fishing","map_pins":"","is_private":false}%

[atsuyuki:~]
$ curl 'localhost:8080/api/widgets/maps?mapId=3' -X DELETE                            [15:21:11]
{"error":"Invalid values"}%
```

- ORDER BY ASC on point names in GET /api/widgets/points
[![Image from Gyazo](https://i.gyazo.com/a228ef14b90bdb0250d7b091fd02f2bf.png)](https://gyazo.com/a228ef14b90bdb0250d7b091fd02f2bf)

- ORDER BY ASC on point names in GET /api/widgets/maps
[![Image from Gyazo](https://i.gyazo.com/e3128196c4799ca2e87b9f0352d5ecac.png)](https://gyazo.com/e3128196c4799ca2e87b9f0352d5ecac)